### PR TITLE
stub vulkan build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,10 @@ if(NOT DAEMON_EXTERNAL_APP)
         option(USE_MUMBLE "Build Daemon with mumblelink sumpport" ON)
     endif()
 
+    if (BUILD_CLIENT)
+        option(USE_VULKAN "Use Vulkan rendering API instead of OpenGL." OFF)
+    endif()
+
     option(USE_SMP "Compile with support for running the renderer in a separate thread" ON)
     option(USE_BREAKPAD "Generate Daemon crash dumps (which require Breakpad tools to read)" OFF)
 endif()
@@ -562,6 +566,13 @@ if (BUILD_CLIENT OR BUILD_TTY_CLIENT OR BUILD_SERVER OR BUILD_DUMMY_APP)
     endif()
 endif()
 
+if (USE_VULKAN)
+    add_definitions("-DDAEMON_RENDERER_VULKAN=1")
+else()
+    add_definitions("-DDAEMON_RENDERER_OPENGL=1")
+endif()
+
+# TODO: Split OpenGL and Vulkan library configuration.
 # Look for OpenGL here before we potentially switch to looking for static libs.
 if (BUILD_CLIENT)
     if (LINUX OR FREEBSD)
@@ -937,9 +948,16 @@ if (BUILD_CLIENT)
     if (USE_SMP)
         list(APPEND Definitions USE_SMP)
     endif()
+
+    if (USE_VULKAN)
+        set(CLIENT_EXECUTABLE_NAME daemon-vulkan)
+    else()
+        set(CLIENT_EXECUTABLE_NAME daemon)
+    endif()
+
     AddApplication(
         Target client
-        ExecutableName daemon
+        ExecutableName ${CLIENT_EXECUTABLE_NAME}
         ApplicationMain ${ENGINE_DIR}/client/ClientApplication.cpp
         Definitions ${Definitions}
         Flags ${WARNINGS}

--- a/src.cmake
+++ b/src.cmake
@@ -77,6 +77,7 @@ set(COMMONTESTLIST
     ${ENGINE_DIR}/qcommon/q_math_test.cpp
 )
 
+# TODO: Split OpenGL and Vulkan list.
 set(RENDERERLIST
     ${ENGINE_DIR}/renderer/BufferBind.h
     ${ENGINE_DIR}/renderer/DetectGLVendors.cpp

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -45,6 +45,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	static void GfxInfo_f();
 
+#if defined(DAEMON_RENDERER_OPENGL)
+	constexpr rendererApi_t rendererApi = rendererApi_t::OPENGL;
+#elif defined(DAEMON_RENDERER_VULKAN)
+	constexpr rendererApi_t rendererApi = rendererApi_t::VULKAN;
+#else
+	#error Undefined renderer API.
+#endif
+
+Cvar::Range<Cvar::Cvar<int>> r_rendererApi( "r_rendererApi", "Renderer API: 0: OpenGL, 1: Vulkan", Cvar::ROM,
+	Util::ordinal( rendererApi ),
+	Util::ordinal( rendererApi_t::OPENGL ),
+	Util::ordinal( rendererApi_t::VULKAN ) );
+
 	cvar_t      *r_glMajorVersion;
 	cvar_t      *r_glMinorVersion;
 	cvar_t      *r_glProfile;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -329,6 +329,12 @@ enum class ssaoMode {
 	  RSPEEDS_NEAR_FAR,
 	};
 
+enum class rendererApi_t
+{
+	OPENGL,
+	VULKAN,
+};
+
 	enum class glDebugModes_t
 	{
 		GLDEBUG_NONE,
@@ -2697,6 +2703,8 @@ enum class ssaoMode {
 //
 // cvars
 //
+	extern Cvar::Range<Cvar::Cvar<int>> r_rendererAPI;
+
 	extern cvar_t *r_glMajorVersion; // override GL version autodetect (for testing)
 	extern cvar_t *r_glMinorVersion;
 	extern cvar_t *r_glProfile;


### PR DESCRIPTION
Still relies on OpenGL for everything, but add the required build-time toggle for a Vulkan build, and report it at run time.

The vulkan client file executable is named `daemon-vulkan`.